### PR TITLE
Show the duration of the past live stream

### DIFF
--- a/lib/WWW/StrawViewer/Utils.pm
+++ b/lib/WWW/StrawViewer/Utils.pm
@@ -683,7 +683,7 @@ sub get_duration {
 sub get_time {
     my ($self, $info) = @_;
 
-    if ($info->{liveNow}) {
+    if ($info->{liveNow} and $self->get_duration($info) = 0) {
         return 'LIVE';
     }
 


### PR DESCRIPTION
I noticed a problem that for recorded streams, the duration is displayed as:
"-> Duration  : LIVE"
For recorded streams, their duration is known.
For such videos, the following fields are returned from API: liveNow=true, lengthSeconds=<non zero>
For really Live streams, fields are returned from API: liveNow=true, lengthSeconds=0
I am not very familiar with Perl. I added showing the actual duration for the recorded streams.